### PR TITLE
Add devcontainer.json for easy environment setup

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,15 @@
+FROM ubuntu:22.04
+
+RUN apt update \
+ && apt install -y \
+        git \
+        clangd \
+        clang-format \
+        python-is-python3 \
+        gcc-mingw-w64 \
+        nasm \
+        python3 \
+ && apt autoremove -y \
+ && rm -rf /var/lib/apt/lists/*
+ 
+ LABEL org.opencontainers.image.source=https://github.com/rtecCyberSec/Packer_Development

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,6 @@
+{
+	"name": "Ubuntu",
+	"build": {
+		"dockerfile": "Dockerfile"
+	}
+}

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+    "recommendations": [
+        "ms-python.python"
+    ]
+}


### PR DESCRIPTION
Makes it easy for people to set up the environment (either locally with Docker or with GitHub Codespaces). I used this in my workshop, thought it might be helpful!

I only added dependencies for the C track, would need some more commands in the `Dockerfile` to also configure the environment for the other tracks. Also see [here](https://github.com/LLVMParty/RemillWorkshop/tree/main/.devcontainer) for an example where I also pushed the image to the repo to make the startup time for the workshop much quicker (optional, but nice).